### PR TITLE
04.06.2020

### DIFF
--- a/Osiris/EventListener.cpp
+++ b/Osiris/EventListener.cpp
@@ -16,7 +16,7 @@ EventListener::EventListener() noexcept
     interfaces->gameEventManager->addListener(this, "player_death");
 }
 
-EventListener::~EventListener()
+void EventListener::remove() noexcept
 {
     assert(interfaces);
 

--- a/Osiris/EventListener.h
+++ b/Osiris/EventListener.h
@@ -7,7 +7,7 @@
 class EventListener : public GameEventListener {
 public:
     EventListener() noexcept;
-    ~EventListener();
+    void remove() noexcept;
     void fireGameEvent(GameEvent* event);
 };
 

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -557,6 +557,7 @@ static DWORD WINAPI unload(HMODULE module) noexcept
     ImGui::DestroyContext();
 
     hooks.reset();
+    eventListener->remove();
     eventListener.reset();
     memory.reset();
     interfaces.reset();

--- a/Osiris/Hooks.h
+++ b/Osiris/Hooks.h
@@ -5,11 +5,6 @@
 #include <type_traits>
 #include <Windows.h>
 
-#include "Interfaces.h"
-#include "Memory.h"
-#include "SDK/Cvar.h"
-#include "SDK/Engine.h"
-
 struct SoundInfo;
 
 class Hooks {


### PR DESCRIPTION
Remove redundant includes from Hooks.h
Add EventListener::remove() method replacing EventListener destructor to fix crash when closing game without prior cheat unload

